### PR TITLE
Template api param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.swp
 *.pyc
 *.coverage
+webapp/*.egg*
 node_modules
-buzzwordipsum.egg-info

--- a/webapp/buzzwordipsum/sentencegenerator.py
+++ b/webapp/buzzwordipsum/sentencegenerator.py
@@ -45,7 +45,10 @@ class SentenceGenerator(object):
                 # Assumes all nouns defined as singulars
                 return ptn.pluralize(self._wp.pick('noun'))
         else:
-            return self._wp.pick(token[0])
+            try:
+                return self._wp.pick(token[0])
+            except KeyError as e:
+                return '[' + tokenStr + ']'
 
     @classmethod
     def factory(cls, conf, wp):

--- a/webapp/buzzwordipsum/sentencegenerator.py
+++ b/webapp/buzzwordipsum/sentencegenerator.py
@@ -18,6 +18,8 @@ class SentenceGenerator(object):
 
     def fillTemplate(self, template):
         """Replace all tokens in a template and return it, also capitalising the first letter."""
+        if template == '': return template
+
         s = re.sub(r'\[(.+?)\]', lambda x: self.replaceToken(x.group(1)), template)
 
         return s[0].upper() + s[1:]

--- a/webapp/buzzwordipsum/test/test_sentencegenerator.py
+++ b/webapp/buzzwordipsum/test/test_sentencegenerator.py
@@ -23,5 +23,9 @@ def testFillTemplate(sg):
 def testFillTemplateWorksOnEmptyString(sg):
     assert sg.fillTemplate('') == ''
 
+def testFillTemplateFailsGracefullyIfUnsupportedTokenPassedIn(sg):
+    assert sg.fillTemplate('We [bob]') == 'We [bob]'
+    assert sg.fillTemplate('We [noun] [bob]').find('[bob]') > -1
+
 def testGetSentence(sg):
     assert sg.getSentence() == 'We aim to virtually virtualise our value-added dot-bomb.'

--- a/webapp/buzzwordipsum/test/test_sentencegenerator.py
+++ b/webapp/buzzwordipsum/test/test_sentencegenerator.py
@@ -20,5 +20,8 @@ def testFillTemplate(sg):
     assert sg.fillTemplate(sg._sentences[0]) == 'We aim to virtually virtualise our value-added dot-bomb.'
     assert sg.fillTemplate(sg._sentences[1]) == 'Virtually virtualising our milestones.'
 
+def testFillTemplateWorksOnEmptyString(sg):
+    assert sg.fillTemplate('') == ''
+
 def testGetSentence(sg):
     assert sg.getSentence() == 'We aim to virtually virtualise our value-added dot-bomb.'

--- a/webapp/buzzwordipsum/webservice.py
+++ b/webapp/buzzwordipsum/webservice.py
@@ -68,9 +68,16 @@ class BuzzwordIpsum(restful.Resource):
                             choices=('html', 'text'),
                             help='Format should be \'html\' or \'text\' (default)',
                             default='text')
+        parser.add_argument('template',
+                            type=str,
+                            help='Template should be a string with words to be replaced in square brackets. e.g. "We [verb] our [noun, PLURAL]" will return a string with the bracketed words replaced. To get different forms/tenses, add options after a comma. Supported word types are adverb, noun, adjective, verb. Supported options are verb, PARTICIPLE and noun, PLURAL.',
+                            default=None)
         args = parser.parse_args()
 
-        paragraphs = [makeParagraph(args['proseType'], wp, sg, self.appconfig) for i in xrange(args['paragraphs'])]
+        if args['template'] is not None:
+            paragraphs = [sg.fillTemplate(args['template'])]
+        else:
+            paragraphs = [makeParagraph(args['proseType'], wp, sg, self.appconfig) for i in xrange(args['paragraphs'])]
 
         if args['format'] == 'text':
             return Response('\n\n'.join(paragraphs) + '\n', content_type='text/plain')


### PR DESCRIPTION
Adding new ?template param, can pass in e.g. 
```template=We [verb] our [noun, PLURAL]```
Also fixing tiny bug with template filler